### PR TITLE
remove globs and read_string from m2 job

### DIFF
--- a/workflow/full.wdl
+++ b/workflow/full.wdl
@@ -259,7 +259,7 @@ workflow Mutect2CHIP {
     
     # Optionally run CHIP
     if (run_chip_detection && defined(annovar_db_archive)) {
-        String tumor_sample_name = Mutect2_wf.tumor_sample
+        String tumor_sample_name = basename(basename(chip_detection_input_vcf, ".gz"), ".vcf")
         call CHIP.CHIP as CHIP_wf {
             input:
                 input_vcf = chip_detection_input_vcf,

--- a/workflow/m2.sj.wdl
+++ b/workflow/m2.sj.wdl
@@ -163,7 +163,6 @@ workflow Mutect2SingleJob {
         File filtered_vcf_idx = M2UKB.filter_output_vcf_idx
         File filtering_stats = M2UKB.filtering_stats
         File mutect_stats = M2UKB.mutect_output_stats
-        String tumor_sample = M2UKB.tumor_sample
         File? bamout = M2UKB.merged_bam_out
         File? bamout_index = M2UKB.merged_bam_out_index
         File read_orientation_model_params = M2UKB.artifact_prior_table
@@ -325,7 +324,6 @@ task M2UKB {
         File filter_output_vcf_idx = filtered_vcf_idx
         File filtering_stats = "~{output_name}.filtering.stats"
         File mutect_output_stats = mutect_stats
-        String tumor_sample = read_string("tumor_name.txt")
         File? merged_bam_out = "~{unfiltered_name}.out.bam"
         File? merged_bam_out_index = "~{unfiltered_name}.out.bai"
         File artifact_prior_table = output_name + "-artifact-priors.tar.gz"


### PR DESCRIPTION
Removed read_string and glob WDL functions from M2 task to prevent long wait times and potential timeout errors when running on the cloud.